### PR TITLE
Add hosts file opening in VS Code and PS reload.

### DIFF
--- a/ps-alias.ps1
+++ b/ps-alias.ps1
@@ -71,6 +71,38 @@ Function global:GitBinding {
     }
 }
 
+# Opens the Windows hosts file in VS code.
+function hosts {
+    code "C:\Windows\System32\drivers\etc\hosts"
+}
+
+# BEGIN POWERSHELL RELOAD
+# Powershell reload is based on code from this article by Øyvind Kallstad. -> https://communary.net/2015/05/28/how-to-reload-the-powershell-console-session/
+# It reloads powershell in the event you have added something to the path or user provile script and needs a 
+# powershell restart in order for it to be recognized.
+function Invoke-PowerShell {
+    powershell -nologo
+    Invoke-PowerShell
+}
+
+function Restart-PowerShell {
+    if ($host.Name -eq 'ConsoleHost') {
+        exit
+    }
+    Write-Warning 'Only usable while in the PowerShell console host'
+}
+
+# This code breaks the powershell reload infinite loop, so it's not calling itself forever.
+$parentProcessId = (Get-WmiObject Win32_Process -Filter "ProcessId=$PID").ParentProcessId
+$parentProcessName = (Get-WmiObject Win32_Process -Filter "ProcessId=$parentProcessId").ProcessName
+
+if ($host.Name -eq 'ConsoleHost') {
+    if (-not($parentProcessName -eq 'powershell.exe')) {
+        Invoke-PowerShell
+    }
+}
+# END POWERSHELL RELOAD
+
+Set-Alias -Name 'reload' -Value 'Restart-PowerShell'
 New-Alias d global:DockerBinding
 New-Alias g global:GitBinding
-


### PR DESCRIPTION
This PR adds two new capabilities to the script.
---
`hosts` - Opens the Windows hosts file in VS Code for quick access. On save, VS Code notices that it needs admin permissions to save and will offer to save as admin.

`reload` - This reloads powershell in-place. This is useful for when you're trying out new user scripts in your powershell profile (like this, for example), or add something to the path that requires a restart.