### PR TITLE
Reversed switch functionality of Syntax function

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ All aliases for Git begin with `g`.
 | ---      | ---
 | reload   | Restarts PowerShell in-place. Useful in the event you have added something to the path or user profile script and need a powershell restart in order for it to be recognized.
 | hosts    | Opens the hosts file in VS Code
+| Syntax   | Prints PowerShell Command Syntax vertically, replicating docs.microsoft.com layout
+| Sort-Reverse   | Reverses the order of an array. Accepts pipeline support e.g. `1,2,3,4,5 | Sort-Reverse`
+
+
 
 ## Contributors
 

--- a/ps-alias.ps1
+++ b/ps-alias.ps1
@@ -113,11 +113,11 @@ function Syntax {
                 }
         Syntax = $true
     }
-    if ($PrettySyntax) {
-        (Get-Command @params) -replace '(\s(?=\[)|\s(?=-))', "`r`n "
+    if ($Normalise) {
+        Get-Command @params
     }
     else {
-        Get-Command @params
+        (Get-Command @params) -replace '(\s(?=\[)|\s(?=-))', "`r`n "
     }
 }
 
@@ -175,7 +175,7 @@ function Restart-PSHost {
         if ($host.Name -eq 'Windows PowerShell ISE Host' -and $psISE.PowerShellTabs.Files.IsSaved -contains $false) {
             if ($Force -or $PSCmdlet.ShouldProcess('Unsaved work detected?','Unsaved work detected. Save changes?','Confirm')) {
                 foreach ($IseTab in $psISE.PowerShellTabs) {
-                    $IseTab.Files | ForEach-Object { 
+                    $IseTab.Files | ForEach-Object {
                         if ($_.IsUntitled -and !$_.IsSaved) {
                             $_.SaveAs($_.FullPath,[System.Text.Encoding]::UTF8)
                         }


### PR DESCRIPTION
I used to have this so you had to provide the switch to print pretty syntax but found I was using it by default so reversed the switch so it always prints vertically. 👍