### PR TITLE
Edit hosts file as Administrator

### DIFF
--- a/ps-alias.ps1
+++ b/ps-alias.ps1
@@ -126,9 +126,25 @@ function Sort-Reverse {
     $input | Sort-Object {(--(Get-Variable rank -Scope 1).Value)}
 }
 
-# Opens the Windows hosts file in VS code.
-function hosts {
-    code "C:\Windows\System32\drivers\etc\hosts"
+# Opens the Windows hosts file in an editor.
+function Edit-HostsFile {
+    [Alias('hosts')]
+    [CmdletBinding()]
+    Param()
+    # TO CONSIDER: Should we take a 
+    # Make sure we're on Windows...
+    if ($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) {
+        # Default editor to notepad.exe
+        $fileEditor = 'notepad'
+        # Find code if it exists. Giving preference to Stable code over insiders.
+        if(Get-Command code -ErrorAction SilentlyContinue) {
+            $fileEditor = 'code'
+        } elseif(Get-Command code-insiders -ErrorAction SilentlyContinue) {
+            $fileEditor = 'code-insiders'
+        }
+        # Use Start-Process to ensure that we're elevated. If already elevated, will not reprompt.
+        Start-Process -FilePath $fileEditor -ArgumentList "C:\Windows\System32\drivers\etc\hosts" -Verb RunAs
+    }
 }
 
 # BEGIN POWERSHELL RELOAD


### PR DESCRIPTION
* Change the editor to fall back on notepad.exe.
* Check if we're on Windows
* Use an approved verb (this will help with #12 so that we don't cause warnings about unapproved verbs)
* Always run the editor as administrator
* Add Alias for hosts

Only Administrators can edit the hosts file. If a user is not running PowerShell elevated (they shouldn't be most of the time...) then this will elevate their editor.