### PR TITLE
Rename Syntax switch

### DIFF
--- a/ps-alias.ps1
+++ b/ps-alias.ps1
@@ -96,10 +96,11 @@ function GitBinding {
 function Syntax {
     [CmdletBinding()]
     param (
+        [Parameter(Mandatory)]
         $Command,
 
         [switch]
-        [Parameter(Alias = 'Normalize')]
+        [Alias('Normalize','Horizontal')]
         $Normalise
     )
 

--- a/ps-alias.ps1
+++ b/ps-alias.ps1
@@ -99,7 +99,8 @@ function Syntax {
         $Command,
 
         [switch]
-        $PrettySyntax
+        [Parameter(Alias = 'Normalize')]
+        $Normalise
     )
 
     $check = Get-Command -Name $Command


### PR DESCRIPTION
Also add an alias for American spelling of Normalize

The previous switch would not actually change behavior.