### PR TITLE
Added Restore-WorkspacePackages

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ All aliases for Git begin with `g`.
 | hosts    | Opens the hosts file in VS Code
 | Syntax   | Prints PowerShell Command Syntax vertically, replicating docs.microsoft.com layout
 | Sort-Reverse   | Reverses the order of an array. Accepts pipeline support e.g. `1,2,3,4,5 | Sort-Reverse`
+| Restore-WorkspacePackages (rwp) | Restores NPM, Nuget, and Libman packages starting at the root folder of a workspace.
 
 
 ## Contributing

--- a/ps-alias.ps1
+++ b/ps-alias.ps1
@@ -1,3 +1,50 @@
+function Restore-WorkspacePackages {
+    [Alias('rwp')]
+    [CmdletBinding(DefaultParameterSetName="Default")]
+    param(
+        [Parameter(ParameterSetName="NPM", HelpMessage="Restore only NPM packages")]
+        [switch]$NPM,
+        [Parameter(ParameterSetName="Nuget", HelpMessage="Restore only Nuget packages")]
+        [switch]$Nuget,
+        [Parameter(ParameterSetName="Libman", HelpMessage="Restore only Library Manager packages")]
+        [switch]$Libman
+    )
+
+    $restoreNpm = -not ($null -eq (Get-Command npm -ErrorAction SilentlyContinue))
+    $restoreDotnet = -not ($null -eq (Get-Command dotnet -ErrorAction SilentlyContinue))
+    $restoreLibman = -not ($null -eq (Get-Command libman -ErrorAction SilentlyContinue))
+
+    if ($restoreNpm -and ($PSCmdlet.ParameterSetName -eq "Default" -or $PSCmdlet.ParameterSetName -eq "NPM")) {
+        Write-Host "Restoring NPM packages"
+        Get-ChildItem -Filter package.json -Recurse | Where-Object Directory -NotLike "*node_module*" | ForEach-Object {
+            Write-Host "-  Restoring $($_.Directory)..." -ForegroundColor Yellow
+            Push-Location $_.Directory
+            npm install --no-save
+            Pop-Location
+        }
+    }
+
+    if ($restoreDotnet -and ($PSCmdlet.ParameterSetName -eq "Default" -or $PSCmdlet.ParameterSetName -eq "Nuget")) {
+        Write-Host "Restoring NuGet packages"
+        Get-ChildItem -Filter *.*proj -Recurse | ForEach-Object {
+            Write-Host "-  Restoring $($_.Directory)..." -ForegroundColor Yellow
+            Push-Location $_.Directory
+            dotnet restore
+            Pop-Location
+        }
+    }
+
+    if ($restoreLibman -and ($PSCmdlet.ParameterSetName -eq "Default" -or $PSCmdlet.ParameterSetName -eq "Libman")) {
+        Write-Host "Restoring Libman packages"
+        Get-ChildItem -Filter libman.json -Recurse | ForEach-Object {
+            Write-Host "-  Restoring $($_.Directory)..." -ForegroundColor Yellow
+            Push-Location $_.Directory
+            libman restore
+            Pop-Location
+        }
+    }
+}
+
 function Invoke-DockerBinding {
     [Alias('d')]
 


### PR DESCRIPTION
I was inspired to add this feature while checking out the 'IO' repo. When you're dealing with multiple projects within the same Workspace it would be helpful to restore all the NPM/NuGet/Libman packages with a single command at the root directory of the Workspace.

Enjoy.

![image](https://user-images.githubusercontent.com/8602418/58671780-b1eb5100-82f8-11e9-9779-5be219d10a75.png)