### PR TITLE
Added a 'default' switch for Docker and Git - Closes #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ All aliases for Docker begin with `d`.
 | d r       | docker run
 | d t       | docker image tag
 | d p       | docker push
+| d ...     | docker ... (where ... is any parameter you use)
 
 
 ### Git
@@ -65,6 +66,7 @@ All aliases for Git begin with `g`.
 | g rs      | git reset
 | g s       | git status
 | g t       | git tag
+| g ...     | git ... (where ... is any parameter you use)
 
 ### Miscellaneous
 

--- a/ps-alias.ps1
+++ b/ps-alias.ps1
@@ -41,6 +41,8 @@ function Invoke-DockerBinding {
         'r' { docker run $Params }
         # push
         'p' { docker push $Params }
+        # catchall
+        default { docker $Cmd $Params }
     }
 }
 
@@ -90,6 +92,8 @@ function Invoke-GitBinding {
         's' { git status $Params }
         # tag
         't' { git tag $Params }
+        # catchall
+        default { git $Cmd $Params }
     }
 }
 


### PR DESCRIPTION
# Purpose

As explained in issue #18, it would be great if the alias for Docker or Git will still work with 'unknown' commands. This PR closes that issue.

![bitmoji](https://render.bitstrips.com/v2/cpanel/d49074c3-3940-476e-9a43-d34df45b71af-b427cfda-a7f5-497f-a483-1061dc3d44a5-v1.png?transparent=1&palette=1&width=246)