### PR TITLE
Update All Contributors badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PowerShell Alias
-[![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributing)
 
 For more information as to how this repo came about, check out this [blog post](https://michaeljolley.com/posts/setup-command-aliases-in-powershell-to-make-life-easier/)
 


### PR DESCRIPTION
There is no contributors anchor. This will take user to Contributing header which is (hopefully) close enough to the contributors.