### PR TITLE
Updated Invoke-GitHubRepository to browse to current branch

### DIFF
--- a/src/Export/GitHub/Invoke-GitHubRepository.Tests.ps1
+++ b/src/Export/GitHub/Invoke-GitHubRepository.Tests.ps1
@@ -6,12 +6,26 @@ Describe("Invoke-GitHubRepository") {
   $repoUrl = "https://github.com/MichaelJolley/devtoolbox"
   $repoSSH = "git@github.com:MichaelJolley/devtoolbox"
 
+  BeforeAll {
+    # Override git.exe file so we can mock it within our tests
+    function git {
+      param(
+        [Parameter(ValueFromRemainingArguments)]
+        [string[]]
+        $PassThruArgs
+      )
+    }
+  }
+
   It("Should open default browser to $repoUrl") {
     Mock -CommandName "git" -MockWith { return $repoUrl }
     Mock -CommandName "Start-Process" -MockWith {
       param($FilePath)
       $Script:cmd = $FilePath
     }
+
+    Invoke-GitHubRepository
+    $cmd | Should -Be $repoUrl
   }
 
   It("Should convert $repoSSH to $repoUrl") {
@@ -23,5 +37,27 @@ Describe("Invoke-GitHubRepository") {
 
     Invoke-GitHubRepository
     $cmd | Should -Be $repoUrl
+  }
+  
+  It("Should open default browser to $repoURL/tree/vnext") {
+    Mock -CommandName "git" -ParameterFilter { $PassThruArgs[0] -eq "config" } -MockWith { return $repoUrl }
+    Mock -CommandName "git" -ParameterFilter { $PassThruArgs[0] -eq "branch" -and $PassThruArgs[1] -eq "--show-current" } -MockWith { return "vnext" }
+    Mock -CommandName "git" -ParameterFilter { $PassThruArgs[0] -eq "branch" -and $PassThruArgs[1] -eq "-r" } -MockWith { return @("origin/vnext") }
+    Mock -CommandName "Start-Process" -MockWith {
+      param($FilePath)
+      $Script:cmd = $FilePath
+    }
+
+    Invoke-GitHubRepository -Branch
+    $cmd | Should -Be ($repoUrl + "/tree/vnext")
+  }
+
+  It("Should throw if branch doesn't exist") {
+    Mock -CommandName "git" -ParameterFilter { $PassThruArgs[0] -eq "config" } -MockWith { return $repoUrl }
+    Mock -CommandName "git" -ParameterFilter { $PassThruArgs[0] -eq "branch" -and $PassThruArgs[1] -eq "--show-current" } -MockWith { return "vnext" }
+    Mock -CommandName "git" -ParameterFilter { $PassThruArgs[0] -eq "branch" -and $PassThruArgs[1] -eq "-r" } -MockWith { return @("origin/main") }
+    Mock -CommandName "Start-Process" -MockWith {}
+
+    { Invoke-GitHubRepository -Branch } | Should -Throw -ExpectedMessage "Git branch 'vnext' does not exist at $repoUrl"
   }
 }

--- a/src/Export/GitHub/Invoke-GitHubRepository.ps1
+++ b/src/Export/GitHub/Invoke-GitHubRepository.ps1
@@ -1,8 +1,21 @@
 Function Invoke-GitHubRepository {
   [Alias('gh')]
-  Param()
+  Param(
+    # Browse the branch
+    [Parameter()]
+    [switch]
+    $Branch
+  )
 
   $GitURL = (git config remote.origin.url)
+
+  if ($Branch) {
+    $CurrentBranch = (git branch --show-current)
+    if (-not ((git branch -r).Trim() -contains "origin/$CurrentBranch")) {
+      Write-Error "Git branch '$CurrentBranch' does not exist at $GitURL. Make sure you have pushed your branch and try again." -ErrorAction Stop
+    }
+    $GitURL += "/tree/$CurrentBranch"
+  }
 
   if ($null -ne $GitURL -and
     $GitURL.Substring(0, 4).ToLower() -eq "http" -and


### PR DESCRIPTION
This PR adds a new feature to the `Invoke-GitHubRepository` (`gh`) cmdlet.

Added a new switch parameter "Branch" which will open a browser window to your github repo selecting the current branch (if it exists).

If your remote repo (origin) does not have a branch that matches your current local branch the cmdlet will throw an error and ask you to push your branch and try again.

![bitmoji](https://sdk.bitmoji.com/render/panel/a48457d3-961f-4399-8505-065d5ac71256-b427cfda-a7f5-497f-a483-1061dc3d44a5-v1.png?transparent=1&palette=1&width=246)